### PR TITLE
Fix unexpected fill rate and pointer rate`SliderElement` when `min` > 0

### DIFF
--- a/packages/player/src/ui/slider/SliderElement.ts
+++ b/packages/player/src/ui/slider/SliderElement.ts
@@ -201,8 +201,9 @@ export class SliderElement extends LitElement {
    * `fillRate` = 0.5 (result)
    */
   get fillRate(): number {
-    const range = this.max - this.min;
-    return range > 0 ? this.value / range : 0;
+    const range = this.max - this.min,
+      offset = this.value - this.min;
+    return range > 0 ? offset / range : 0;
   }
 
   /**
@@ -229,8 +230,9 @@ export class SliderElement extends LitElement {
    * @default 0
    */
   get pointerRate() {
-    const range = this.max - this.min;
-    return range > 0 ? this.pointerValue / range : 0;
+    const range = this.max - this.min,
+      offset = this.pointerValue - this.min;
+    return range > 0 ? offset / range : 0;
   }
 
   /**


### PR DESCRIPTION
when the `min` of slider element is set to value larger than 0, the fill rate and pointer rate may exceed 1, thereby causing styling issues, this PR should fix this issue. 

For example: 
https://github.com/vidstack/player/blob/34ee665fd44cfdcb99813cee7730a25e892b3e24/src/ui/slider/SliderElement.ts#L203-L206
```js
  /**
   * The current value to range ratio.
   *
   * @default 0.5
   * @example
   * `min` = 9
   * `max` = 10
   * `value` = 9
   * `range` = 1 (max - min)
   * `fillRate` = 9 (result)
   */
  get fillRate(): number {
    const range = this.max - this.min;
    return range > 0 ? this.value / range : 0;
  }
```