### PR TITLE
Add globals type entry point

### DIFF
--- a/packages/vidstack/package.json
+++ b/packages/vidstack/package.json
@@ -123,7 +123,10 @@
       "types": "./elements.json.d.ts",
       "default": "./elements.json"
     },
-    "./vscode.html-data.json": "./vscode.html-data.json"
+    "./vscode.html-data.json": "./vscode.html-data.json",
+    "./globals": {
+      "types": "./globals.d.ts"
+    }
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
### Description:

<!-- What changes are being made? What feature/bug is being fixed here? -->

When using `modueResolution` of type `Bundler` and you want to use `vidstack/globals` in `tsconfig.json`, typescript won't find the file as it's not specified as an entry point. When using `moduleResolution` of type `Node`, you can use it without further ado.

This PR fixes the error by specifying an explicit entry point for the `vidstack/globals` type definition file. If there's better sugar available, feel free to teach me.


### Ready?

✅ Yes
